### PR TITLE
Fix for fast scrolling with lots of remotely stored photos, selection near beginning and end

### DIFF
--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -147,6 +147,7 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
 
 - (void)dealloc
 {
+    [self.imageManager stopCachingImagesForAllAssets];
     [self unregisterChangeObserver];
     [self removeNotificationObserver];
 }


### PR DESCRIPTION
When you select a recent asset, then quickly scroll through many images, select another image, and tap done, the pre heat cache does not release, resulting in a lock.  This one line change solves the issue.


In CTAssetsGridViewController.m, in -(void)dealloc, add:

    [self.imageManager stopCachingImagesForAllAssets];
